### PR TITLE
Sync experience section with latest resume

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
       <h1 class="text-4xl md:text-7xl font-extrabold text-ink display-font">Rohith S.</h1>
       <h2 class="text-4xl md:text-7xl font-extrabold text-muted display-font">I build scalable backend systems.</h2>
       <p class="max-w-xl mt-6 text-muted">
-        I'm a backend-focused Software Engineer with 5+ years of experience specializing in building high-performance,
+        I'm a backend-focused Software Engineer with 6+ years of experience specializing in building high-performance,
         scalable systems with Java, Spring Boot, and AWS. I'm passionate about architecting robust APIs and deploying
         resilient cloud-native applications.
       </p>
@@ -328,6 +328,9 @@
             <span class="pill px-3 py-1 rounded-full">AWS</span>
             <span class="pill px-3 py-1 rounded-full">Docker</span>
             <span class="pill px-3 py-1 rounded-full">Kubernetes</span>
+            <span class="pill px-3 py-1 rounded-full">Kafka</span>
+            <span class="pill px-3 py-1 rounded-full">Redis</span>
+            <span class="pill px-3 py-1 rounded-full">LangChain</span>
             <span class="pill px-3 py-1 rounded-full">Microservices</span>
             <span class="pill px-3 py-1 rounded-full">REST APIs</span>
             <span class="pill px-3 py-1 rounded-full">SQL & NoSQL</span>
@@ -352,39 +355,31 @@
       </h2>
       <div class="space-y-8 stagger">
         <div class="experience-card p-8 rounded-lg shadow-xl">
-          <h3 class="text-xl font-bold text-ink">Software Developer <span class="text-accent">@ Viacore</span>
+          <h3 class="text-xl font-bold text-ink">Software Engineer <span class="text-accent">@ Viacore</span>
           </h3>
-          <p class="text-sm text-muted mb-4">Oct 2024 - Present</p>
+          <p class="text-sm text-muted mb-4">Jul 2023 - Present</p>
           <ul class="space-y-2 text-muted text-sm">
-            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Built AI microservices with Java
-              Spring Boot, integrating RAG pipelines via LangChain for real-time generative AI responses.</li>
-            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Enhanced application security by
-              40% using OAuth 2.0, JWT, and Spring Security.</li>
-            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Cut deployment time by 25% by
-              automating workflows with AWS CodePipeline.</li>
+            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Designed a RAG pipeline on
+              LangChain + Pinecone that returns grounded answers in under 800ms, cutting manual lookup time by
+              roughly a third.</li>
+            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Brought p95 API latency from
+              ~420ms down to ~260ms via Redis caching and JDBC query tuning.</li>
+            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Migrated batch jobs onto AWS
+              Lambda and containerized services with Docker/Kubernetes, trimming AWS spend ~18% and holding 99.9%
+              uptime.</li>
           </ul>
         </div>
         <div class="experience-card p-8 rounded-lg shadow-xl">
-          <h3 class="text-xl font-bold text-ink">Software Developer <span class="text-accent">@ Norstella
-              (Contract)</span></h3>
-          <p class="text-sm text-muted mb-4">Jul 2023 - Oct 2024</p>
-          <ul class="space-y-2 text-muted text-sm">
-            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Designed and implemented RESTful
-              APIs using Java Spring Boot, increasing system performance by 25%.</li>
-            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Led the migration of applications
-              to AWS Lambda and EC2, ensuring 99.99% uptime and reducing resource overhead by 15% with Docker and
-              Kubernetes.</li>
-          </ul>
-        </div>
-        <div class="experience-card p-8 rounded-lg shadow-xl">
-          <h3 class="text-xl font-bold text-ink">Software Developer <span class="text-accent">@ Tata Consultancy
+          <h3 class="text-xl font-bold text-ink">Software Engineer <span class="text-accent">@ Tata Consultancy
               Services</span></h3>
           <p class="text-sm text-muted mb-4">Jan 2019 - Aug 2021</p>
           <ul class="space-y-2 text-muted text-sm">
-            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Developed a microservice-based
-              architecture using Spring Boot, improving scalability and reducing response time by 20%.</li>
-            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Integrated Apache Kafka for
-              real-time event streaming, boosting data processing efficiency by 30%.</li>
+            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Built a Spring Boot microservice
+              platform for a large US bank handling ~1.5M transactions/day.</li>
+            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Replaced a nightly batch sync
+              with Kafka event streaming, cutting reporting lag from a day to minutes.</li>
+            <li class="flex items-start"><span class="text-accent mr-3 mt-1">▹</span>Pushed test coverage from ~55%
+              to 90% with JUnit/Mockito; Kibana + Splunk dashboards are still used by on-call.</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Hero intro: \`5+ years\` → \`6+ years\` to match the updated resume
- Removed the Norstella contract card from the Experience section
- Merged Viacore into a single \`Jul 2023 - Present\` role with richer, resume-aligned bullets (RAG pipeline latency, Redis + JDBC tuning, Lambda/Kubernetes migration with real cost/uptime figures)
- Refreshed TCS bullets with the same human-tone wording as the resume (1.5M txns/day, Kafka batch→stream, 55%→90% coverage, Kibana/Splunk)
- Added \`Kafka\`, \`Redis\`, and \`LangChain\` pills to core-tech list so the site matches the resume's skills grouping
- No JS, CSS, or layout changes — content-only

## Test plan
- [ ] After merge, wait ~1 min for GitHub Pages redeploy
- [ ] Load https://svrohith9.github.io/ and verify:
  - Hero reads \"6+ years of experience\"
  - Experience section shows exactly 2 cards (Viacore + TCS, no Norstella)
  - Viacore date reads \"Jul 2023 - Present\"
  - New \`Kafka\`, \`Redis\`, \`LangChain\` pills appear under About → Core Technologies